### PR TITLE
Removing sys and warnings from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
-sys
 warnings
 argparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests
-warnings
 argparse


### PR DESCRIPTION
sys and warning are built-in modules in python and doesn't require installation. running pip install -r requirements.txt will fail.